### PR TITLE
Fixed GNU/Linux build.

### DIFF
--- a/src/game/server/ai_blended_movement.h
+++ b/src/game/server/ai_blended_movement.h
@@ -232,9 +232,9 @@ public:
 
 	float MaxYawSpeed( void )
 	{
-		float override = GetBlendedMotor()->OverrideMaxYawSpeed( this->GetActivity() );
-		if ( override != -1 )
-			return override;
+		float result = GetBlendedMotor()->OverrideMaxYawSpeed( this->GetActivity() );
+		if ( result != -1 )
+			return result;
 		return BaseClass::MaxYawSpeed();
 	}
 

--- a/src/game/server/ai_network.h
+++ b/src/game/server/ai_network.h
@@ -86,7 +86,7 @@ public:
 // Purpose: Stores a node graph through which an AI may pathfind
 //-----------------------------------------------------------------------------
 
-class CAI_Network final : public IPartitionEnumerator
+class CAI_Network : public IPartitionEnumerator
 {
 public:
 	CAI_Network();

--- a/src/game/server/physics.cpp
+++ b/src/game/server/physics.cpp
@@ -1170,11 +1170,11 @@ void PhysSolidOverride( solid_t &solid, string_t overrideScript )
 	}
 }
 
-void PhysSetMassCenterOverride( masscenteroverride_t &override )
+void PhysSetMassCenterOverride( masscenteroverride_t &flOverride )
 {
-	if ( override.entityName != NULL_STRING )
+	if ( flOverride.entityName != NULL_STRING )
 	{
-		g_PhysicsHook.m_massCenterOverrides.AddToTail( override );
+		g_PhysicsHook.m_massCenterOverrides.AddToTail( flOverride );
 	}
 }
 
@@ -1200,9 +1200,9 @@ void PhysGetMassCenterOverride( CBaseEntity *pEntity, vcollide_t *pCollide, soli
 
 	if ( index >= 0 )
 	{
-		masscenteroverride_t &override = g_PhysicsHook.m_massCenterOverrides[index];
-		Vector massCenterWS = override.center;
-		switch ( override.alignType )
+		masscenteroverride_t &flOverride = g_PhysicsHook.m_massCenterOverrides[index];
+		Vector massCenterWS = flOverride.center;
+		switch ( flOverride.alignType )
 		{
 		case masscenteroverride_t::ALIGN_POINT:
 			VectorITransform( massCenterWS, pEntity->EntityToWorldTransform(), solidOut.massCenterOverride );
@@ -1212,8 +1212,8 @@ void PhysGetMassCenterOverride( CBaseEntity *pEntity, vcollide_t *pCollide, soli
 				Vector massCenterLocal, defaultMassCenterWS;
 				physcollision->CollideGetMassCenter( pCollide->solids[solidOut.index], &massCenterLocal );
 				VectorTransform( massCenterLocal, pEntity->EntityToWorldTransform(), defaultMassCenterWS );
-				massCenterWS += override.axis * 
-					( DotProduct(defaultMassCenterWS,override.axis) - DotProduct( override.axis, override.center ) );
+				massCenterWS += flOverride.axis * 
+					( DotProduct(defaultMassCenterWS,flOverride.axis) - DotProduct( flOverride.axis, flOverride.center ) );
 				VectorITransform( massCenterWS, pEntity->EntityToWorldTransform(), solidOut.massCenterOverride );
 			}
 			break;

--- a/src/game/server/scripted.cpp
+++ b/src/game/server/scripted.cpp
@@ -2129,12 +2129,12 @@ bool CAI_ScriptedSentence::AcceptableSpeaker( CAI_BaseNPC *pNPC )
 			if ( pNPC->GetTarget() == NULL || !pNPC->GetTarget()->IsPlayer() )
 				return false;
 		}
-		bool override;
+		bool bOverride;
 		if ( m_spawnflags & SF_SENTENCE_INTERRUPT )
-			override = true;
+			bOverride = true;
 		else
-			override = false;
-		if ( pNPC->CanPlaySentence( override ) )
+			bOverride = false;
+		if ( pNPC->CanPlaySentence( bOverride ) )
 			return true;
 	}
 	return false;

--- a/src/public/vgui_controls/BuildGroup.h
+++ b/src/public/vgui_controls/BuildGroup.h
@@ -34,7 +34,7 @@ namespace vgui
 // Purpose: a BuildGroup is a list of panels contained in a window (the contextPanel)
 //			Members of this group are viewable and editable in Build Mode, via the BuildModeDialog wizard
 //-----------------------------------------------------------------------------
-class BuildGroup final
+class BuildGroup
 {
 	DECLARE_HANDLES( BuildGroup, 20 );
 


### PR DESCRIPTION
**There is *no* code from tf_port, NextBot or any "legally gray project" in this pull request.**

These are small code fixes (renaming a few variables and removing a few `final` keywords) that prevented GCC (4.6.3, Steam Runtime) from building the source code on GNU/Linux.

Interestingly, Valve's original SDK code compiles correctly without having to rename the `override` variables.

Binaries generated from the associated commit can be found [here](https://github.com/ChampionCynthia/Open-Fortress-Source-Base/releases/tag/ca41757).